### PR TITLE
fix checksums and remove useless genomes

### DIFF
--- a/asset_pep/assets.csv
+++ b/asset_pep/assets.csv
@@ -29,8 +29,6 @@ Cicer_arietinum__LIS_v1_0,fasta,Cicer arietinum  LIS v1.0
 Cajanus_cajan__Penguin_Genomics_v5_0,fasta,Cajanus cajan  Penguin Genomics v5.0
 Coffea_canephora__Coffee_Genome_Hub_v1,fasta,Coffea canephora  Coffee Genome Hub v1
 Citrus_clementina__JGI_v1_0,fasta,Citrus clementina  JGI v1.0
-Chondrus_crispus_ENSEMBL_protists__release_28,fasta,Chondrus crispus ENSEMBL protists  release 28
-Caenorhabditis_elegans_ENSEMBL_release_81,fasta,Caenorhabditis elegans ENSEMBL release 81
 Citrullus_lanatus_Cucurbit_Genomics_Database,fasta,Citrullus lanatus Cucurbit Genomics Database
 Citrullus_lanatus__Cucurbit_Genomics_Database_v1_0,fasta,Citrullus lanatus  Cucurbit Genomics Database v1.0
 Cucumis_melo__Melonomics_v3_5,fasta,Cucumis melo  Melonomics v3.5
@@ -49,14 +47,11 @@ Cucumis_sativus_L___JGI_v1_0,fasta,Cucumis sativus L.  JGI v1.0
 Citrus_sinensis_JGI_v1_assembly_and_v1_0_annotation,fasta,Citrus sinensis JGI v1 assembly and v1.0 annotation
 Coccomyxa_subellipsoidea_C-169_JGI_2_0_Phytozome_10_2,fasta,Coccomyxa subellipsoidea C-169 JGI 2.0 (Phytozome 10.2)
 Daucus_carota__JGI_v2_0,fasta,Daucus carota  JGI v2.0
-Dictyostelium_discoideum__ENSEMBL_protist_release_28,fasta,Dictyostelium discoideum  ENSEMBL protist release 28
-Drosophila_melanogaster_ENSEMBL_release_81,fasta,Drosophila melanogaster ENSEMBL release 81
 Eucalyptus_grandis_JGI_assembly_v1_0_annotation_v1_1,fasta,Eucalyptus grandis JGI assembly v1.0- annotation v1.1
 Eucalyptus_grandis__JGI_v2_0,fasta,Eucalyptus grandis  JGI v2.0
 Elaeis_guineensis_NCBI_Genome_v1_0,fasta,Elaeis guineensis NCBI Genome v1.0
 Elaeis_guineensis_EG5_1,fasta,Elaeis guineensis EG5.1
 Erythranthe_guttata__JGI_v2_0,fasta,Erythranthe guttata  JGI v2.0
-Emiliania_huxleyi__ENSEMBL_protist_release_28,fasta,Emiliania huxleyi  ENSEMBL protist release 28
 Ectocarpus_siliculosus_Ghent_University,fasta,Ectocarpus siliculosus Ghent University
 Fragilariopsis_cylindrus_JGI_1_0,fasta,Fragilariopsis cylindrus JGI 1.0
 Fragaria_vesca_Strawberry_Genome_1_0,fasta,Fragaria vesca Strawberry Genome 1.0
@@ -65,9 +60,7 @@ Glycine_max_JGI_Glyma1_1_annotation_of_the_chromosome-based_Glyma1_assembly,fast
 Glycine_max__JGI_Wm82_a2_v1,fasta,Glycine max  JGI Wm82.a2.v1
 Gossypium_raimondii_JGI_annotation_v2_1_on_assembly_v2_0,fasta,Gossypium raimondii JGI annotation v2.1 on assembly v2.0
 Gossypium_raimondii__JGI_v2_1,fasta,Gossypium raimondii  JGI v2.1
-Galdieria_sulphuraria_ENSEMBL_protists__release_28,fasta,Galdieria sulphuraria ENSEMBL protists  release 28
 Hevea_brasiliensis__NCBI_Genomes_v1,fasta,Hevea brasiliensis  NCBI Genomes v1
-Homo_sapiens_ENSEMBL_release_81,fasta,Homo sapiens ENSEMBL release 81
 Helicosporidium_sp___Illinois_University_1_0,fasta,Helicosporidium sp.  Illinois University 1.0
 Hordeum_vulgare_MIPS,fasta,Hordeum vulgare MIPS
 Hordeum_vulgare_Ensembl_Genomes_ASM32608v1,fasta,Hordeum vulgare Ensembl Genomes ASM32608v1
@@ -86,8 +79,6 @@ Micromonas_pusilla_strain_CCMP1545_Ghent_University,fasta,Micromonas pusilla str
 Micromonas_sp_RCC299_JGI_3_0,fasta,Micromonas sp RCC299 JGI 3.0
 Medicago_truncatula_JCVI_4_0,fasta,Medicago truncatula JCVI 4.0
 Medicago_truncatula__JGI_Mt4_0v1,fasta,Medicago truncatula  JGI Mt4.0v1
-Mus_musculus_ENSEMBL_release_81,fasta,Mus musculus ENSEMBL release 81
-Nannochloropsis_gaditana__ENSEMBL_protist_release_28,fasta,Nannochloropsis gaditana  ENSEMBL protist release 28
 Nelumbo_nucifera__LOTUS-DB_v1_1,fasta,Nelumbo nucifera  LOTUS-DB v1.1
 Oryza_brachyantha_Ensembl_Plants_v1_4b,fasta,Oryza brachyantha Ensembl Plants v1.4b
 Ostreococcus_lucimarinus_JGI_v2_0_assembly_and_annotation,fasta,Ostreococcus lucimarinus JGI v2.0 assembly and annotation
@@ -106,7 +97,6 @@ Petunia_axillaris__Sol_Genomics_v1_6_2,fasta,Petunia axillaris  Sol Genomics v1.
 Pyrus_bretschneideri__Pear_Genome_Project_v1_0,fasta,Pyrus bretschneideri  Pear Genome Project v1.0
 Phyllostachys_edulis_NCGR_v1_0,fasta,Phyllostachys edulis NCGR v1.0
 Phalaenopsis_equestris_Genomics_v1_0,fasta,Phalaenopsis equestris Genomics v1.0
-Phytophtora_sojae__ENSEMBL_protist_release_28,fasta,Phytophtora sojae  ENSEMBL protist release 28
 Physcomitrella_patens_JGI_assembly_release_v1_1_and_COSMOSS_annotation_v1_6,fasta,Physcomitrella patens JGI assembly release v1.1 and COSMOSS annotation v1.6
 Physcomitrella_patens__JGI_v3_3,fasta,Physcomitrella patens  JGI v3.3
 Physcomitrella_patens_Phytozome_9_1_v1_6,fasta,Physcomitrella patens Phytozome 9.1 (v1.6)
@@ -114,16 +104,13 @@ Prunus_persica_JGI_release_v1_0,fasta,Prunus persica JGI release v1.0
 Prunus_persica__JGI_v2_1,fasta,Prunus persica  JGI v2.1
 Picochlorum_RCC4223__ORCAE,fasta,Picochlorum_RCC4223  ORCAE
 Picochlorum_sp__SENEW3_SE3_Rutgers_University_1_0,fasta,Picochlorum sp. SENEW3 (SE3) Rutgers University 1.0
-Paramecium_tetraurelia__ENSEMBL_protist_release_28,fasta,Paramecium tetraurelia  ENSEMBL protist release 28
 Populus_trichocarpa_JGI_assembly_release_v3_0_annotation_v3_0,fasta,Populus trichocarpa JGI assembly release v3.0- annotation v3.0
 Populus_trichocarpa__JGI_v3_1,fasta,Populus trichocarpa  JGI v3.1
 Phaeodactylum_tricornutum_ASM15095v2,fasta,Phaeodactylum tricornutum ASM15095v2
 Ricinus_communis_JCVI_1_0,fasta,Ricinus communis JCVI 1.0
 Ricinus_communis__JGI_v0_1,fasta,Ricinus communis  JGI v0.1
-Saccharomyces_cerevisiae_strain_S288C_ENSEMBL_release_81,fasta,Saccharomyces cerevisiae strain S288C ENSEMBL release 81
 Sorghum_bicolor_JGI_1_4,fasta,Sorghum bicolor JGI 1.4
 Sorghum_bicolor_JGI_v3_1,fasta,Sorghum bicolor JGI v3.1
-Schizosaccharomyces_pombe__ENSEMBL_fungi_release_28,fasta,Schizosaccharomyces pombe  ENSEMBL fungi release 28
 Setaria_italica_JGI_8_3X_chromosome-scale_assembly_release_2_0_annotation_version_2_1,fasta,Setaria italica JGI 8.3X chromosome-scale assembly release 2.0- annotation version 2.1
 Setaria_italica_JGI_v2_2,fasta,Setaria italica JGI v2.2
 Solanum_lycopersicum_ITAG_2_3,fasta,Solanum lycopersicum ITAG 2.3

--- a/asset_pep/recipe_inputs.csv
+++ b/asset_pep/recipe_inputs.csv
@@ -29,8 +29,6 @@ Cicer_arietinum__LIS_v1_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pub
 Cajanus_cajan__Penguin_Genomics_v5_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/ccaj.con.gz,files,3bb3895fd2180702a7773ac6b172dc72
 Coffea_canephora__Coffee_Genome_Hub_v1-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/ccan.con.gz,files,200afa6c2d395b571874baab81b0bba1
 Citrus_clementina__JGI_v1_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/ccl.con.gz,files,d94b4dbb04a352cf7df879d9039de931
-Chondrus_crispus_ENSEMBL_protists__release_28-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/ccr.fasta.gz,files,5d2634aa3b3b62ea8106a34cd572a193
-Caenorhabditis_elegans_ENSEMBL_release_81-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/cel.fasta.gz,files,22731f585bb50a2f0912052e4ae71638
 Citrullus_lanatus_Cucurbit_Genomics_Database-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_03/Genomes/cla.con.gz,files,c7f6bfac86c75422ea567dfae5278b0f
 Citrullus_lanatus__Cucurbit_Genomics_Database_v1_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/cla.con.gz,files,64f13276e1324e230acfc73095bd14bb
 Cucumis_melo__Melonomics_v3_5-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/cme.con.gz,files,cdd23cc59fd079e6345b8d939ca7a200
@@ -49,14 +47,11 @@ Cucumis_sativus_L___JGI_v1_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_
 Citrus_sinensis_JGI_v1_assembly_and_v1_0_annotation-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_03/Genomes/csi.con.gz,files,f1952cd15230a191a11982da0d88f07f
 Coccomyxa_subellipsoidea_C-169_JGI_2_0_Phytozome_10_2-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/cvu.fasta.gz,files,4c226bef275df8f8fea3ccae66c44596
 Daucus_carota__JGI_v2_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/dca.con.gz,files,a661c01682987d830cbf4e01543e09d2
-Dictyostelium_discoideum__ENSEMBL_protist_release_28-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/ddi.fasta.gz,files,a414430e52ea0c6b298dc396f7921edf
-Drosophila_melanogaster_ENSEMBL_release_81-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/drm.fasta.gz,files,08751b07c9a9f62dddd8ab03f92b55e0
 Eucalyptus_grandis_JGI_assembly_v1_0_annotation_v1_1-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_03/Genomes/egr.con.gz,files,e20dce2787119ce7fdb4773e915e851a
 Eucalyptus_grandis__JGI_v2_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/egr.con.gz,files,defeca35c7d6674c2f99e9c2c2abbbc7
 Elaeis_guineensis_NCBI_Genome_v1_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_monocots_04/Genomes/egu.con.gz,files,3b1f353e54487e103acebfc733e46a16
 Elaeis_guineensis_EG5_1-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_monocots_04_5/Genomes/egu.fasta.gz,files,74cf676a593b856fe9a6d262b9739b40
 Erythranthe_guttata__JGI_v2_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/egut.con.gz,files,aa3653ff6f11451b1f5366fa2a650987
-Emiliania_huxleyi__ENSEMBL_protist_release_28-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/emh.fasta.gz,files,1f4bd291d7043b00383c47e55fda4912
 Ectocarpus_siliculosus_Ghent_University-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/esi.fasta.gz,files,472fc9c4a77a2abb814cc75e50526898
 Fragilariopsis_cylindrus_JGI_1_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/fcy.fasta.gz,files,112b7e6f2451396152c5a0b523396073
 Fragaria_vesca_Strawberry_Genome_1_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_03/Genomes/fve.con.gz,files,c02ef9a97d025ac2ec4c43bce12c4963
@@ -65,9 +60,7 @@ Glycine_max_JGI_Glyma1_1_annotation_of_the_chromosome-based_Glyma1_assembly-fast
 Glycine_max__JGI_Wm82_a2_v1-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/gma.con.gz,files,f5fe43d532164de827449fa7f524b6e7
 Gossypium_raimondii_JGI_annotation_v2_1_on_assembly_v2_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_03/Genomes/gra.con.gz,files,4cddab5de17b670495047446160605df
 Gossypium_raimondii__JGI_v2_1-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/gra.con.gz,files,b1fa165124179a69fbddf55c8856b1e5
-Galdieria_sulphuraria_ENSEMBL_protists__release_28-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/gsu.fasta.gz,files,d5ba0b76bf0a987796c5677645d8132f
 Hevea_brasiliensis__NCBI_Genomes_v1-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/hbr.con.gz,files,7c5db4f436dd3994d8205dfb5165026c
-Homo_sapiens_ENSEMBL_release_81-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/hom.fasta.gz,files,980a65be26e611f9cdacec5410691f08
 Helicosporidium_sp___Illinois_University_1_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/hsp.fasta.gz,files,49d843386f7c3ec1455ecf41759e32c8
 Hordeum_vulgare_MIPS-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_monocots_03/Genomes/hvu.con.gz,files,9714c4560a336c12568316854423b045
 Hordeum_vulgare_Ensembl_Genomes_ASM32608v1-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_monocots_04/Genomes/hvu.con.gz,files,75d3d6b92098b90842c5ae780d4d0771
@@ -86,8 +79,6 @@ Micromonas_pusilla_strain_CCMP1545_Ghent_University-fasta,fasta,ftp://ftp.psb.ug
 Micromonas_sp_RCC299_JGI_3_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/mrcc299.fasta.gz,files,816b6ded30370b66052a3c69fee79c5b
 Medicago_truncatula_JCVI_4_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_03/Genomes/mtr.con.gz,files,a93e36442d69a39bba57f5c7c5c02983
 Medicago_truncatula__JGI_Mt4_0v1-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/mtr.con.gz,files,02536fb2669097170ae080bccc12cbc0
-Mus_musculus_ENSEMBL_release_81-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/mus.fasta.gz,files,5b98d9479f7a0aa1ed8e320ab4ce74dc
-Nannochloropsis_gaditana__ENSEMBL_protist_release_28-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/nga.fasta.gz,files,5fe25b00315140e9f58c1bd86c772f65
 Nelumbo_nucifera__LOTUS-DB_v1_1-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/nnu.con.gz,files,5e4cef855de2a4ec3ee0d53afb701f89
 Oryza_brachyantha_Ensembl_Plants_v1_4b-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_monocots_04_5/Genomes/obr.fasta.gz,files,ea80744386421658dbea878a8458144e
 Ostreococcus_lucimarinus_JGI_v2_0_assembly_and_annotation-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_03/Genomes/olu.con.gz,files,20bfc449af6a2261ca915033d1aab370
@@ -106,7 +97,6 @@ Petunia_axillaris__Sol_Genomics_v1_6_2-fasta,fasta,ftp://ftp.psb.ugent.be/pub/pl
 Pyrus_bretschneideri__Pear_Genome_Project_v1_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/pbr.con.gz,files,a0606341c1af1189baddca9244d8aa2b
 Phyllostachys_edulis_NCGR_v1_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_monocots_04_5/Genomes/ped.fasta.gz,files,4b4e34c57f9c06e6a3de6a6d54c9593a
 Phalaenopsis_equestris_Genomics_v1_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_monocots_04_5/Genomes/peq.fasta.gz,files,624b81275c4a7189f20dfba6ae76933e
-Phytophtora_sojae__ENSEMBL_protist_release_28-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/phs.fasta.gz,files,aaf78e1bad09091b2517e3cf9704914a
 Physcomitrella_patens_JGI_assembly_release_v1_1_and_COSMOSS_annotation_v1_6-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_03/Genomes/ppa.con.gz,files,ca9e1ce21907600a70add71bd29b9844
 Physcomitrella_patens__JGI_v3_3-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/ppa.con.gz,files,37f0bf600a262bb545e4197b9a788859
 Physcomitrella_patens_Phytozome_9_1_v1_6-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/ppa.fasta.gz,files,1474d37f033201d23683036edb0ac0f2
@@ -114,16 +104,13 @@ Prunus_persica_JGI_release_v1_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/pla
 Prunus_persica__JGI_v2_1-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/ppe.con.gz,files,87fbd38a27e0e9d4c661f688e0b170ed
 Picochlorum_RCC4223__ORCAE-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/prcc4223.fasta.gz,files,98c1637f0f81bc6f338eff4818fb049e
 Picochlorum_sp__SENEW3_SE3_Rutgers_University_1_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/pse3.fasta.gz,files,35704bd601f1f00c283338ccf000005a
-Paramecium_tetraurelia__ENSEMBL_protist_release_28-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/pte.fasta.gz,files,69b14dab0e274afd6c910a886039f1d6
 Populus_trichocarpa_JGI_assembly_release_v3_0_annotation_v3_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_03/Genomes/ptr.con.gz,files,49789fb7488f991bdd0619437741948a
 Populus_trichocarpa__JGI_v3_1-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/ptr.con.gz,files,d75d8a61d4a84b54673d6d711a8a0d62
 Phaeodactylum_tricornutum_ASM15095v2-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/ptri.fasta.gz,files,26b32f6d9846fc81e764d092df9de479
 Ricinus_communis_JCVI_1_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_03/Genomes/rco.con.gz,files,fab6c0054eb3030d5d5a441efb538817
 Ricinus_communis__JGI_v0_1-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/rco.con.gz,files,3508b3ce108fc78156796f0b8bb174f7
-Saccharomyces_cerevisiae_strain_S288C_ENSEMBL_release_81-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/sac.fasta.gz,files,60516d83e15cb1933b7dd1ad9f96cca7
 Sorghum_bicolor_JGI_1_4-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_monocots_03/Genomes/sbi.con.gz,files,b164b172d671a6a393c09d5f7abdb84b
 Sorghum_bicolor_JGI_v3_1-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_monocots_04_5/Genomes/sbi.fasta.gz,files,813ebb087fac33199119266d2e4ad2ef
-Schizosaccharomyces_pombe__ENSEMBL_fungi_release_28-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/scp.fasta.gz,files,06a22714f5f69f9063eaa2e56e46f9f0
 Setaria_italica_JGI_8_3X_chromosome-scale_assembly_release_2_0_annotation_version_2_1-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_monocots_03/Genomes/sit.con.gz,files,9ede8e22816d388ad63d17f4f22397e2
 Setaria_italica_JGI_v2_2-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_monocots_04_5/Genomes/sit.fasta.gz,files,650591c5e36fa5ab60ae3e5d1d30555d
 Solanum_lycopersicum_ITAG_2_3-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_03/Genomes/sly.con.gz,files,a226442514ec53541a02b248851373e9

--- a/asset_pep/recipe_inputs.csv
+++ b/asset_pep/recipe_inputs.csv
@@ -73,7 +73,7 @@ Hordeum_vulgare_MIPS-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_m
 Hordeum_vulgare_Ensembl_Genomes_ASM32608v1-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_monocots_04/Genomes/hvu.con.gz,files,75d3d6b92098b90842c5ae780d4d0771
 Hordeum_vulgare_IBC_PGSB_v2-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_monocots_04_5/Genomes/hvu.fasta.gz,files,25f9bdf9b34bbb4f5f032537eb91a1a5
 Lotus_japonicus_Kazusa_2_5-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_03/Genomes/lja.con.gz,files,2cf39464a83c4d1cee46bea8f28d41b9
-Musa_acuminata_Genescope-Cirad-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_monocots_03/Genomes/mac.con.gz,files,f2e587473d858fffe64b60899ea1e045
+Musa_acuminata_Genescope-Cirad-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_monocots_03/Genomes/mac.con.gz,files,6a72c6dbf8433ed12408c84e8f36f0ac
 Musa_acuminata_Banana_Genome_v1_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_monocots_04/Genomes/mac.con.gz,files,fa8b6978201546f563ce989aef036a39
 Musa_acuminata_Banana_Genome_v2_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_monocots_04_5/Genomes/mac.fasta.gz,files,13407ead82895f092e1e41c908f8c038
 Micromonas_commoda__JGI_v3_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/mco.con.gz,files,ebdaa1d8ccda0dd2150f42db8c7ce84e
@@ -142,7 +142,7 @@ Theobroma_cacao__RefSeq_v1_1-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_
 Tarenaya_hassleriana__RefSeq_v1-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/tha.con.gz,files,a7774c31ea15e70876b779f38d6c6fee
 Thellungiella_parvula_TpV84-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_03/Genomes/tpa.con.gz,files,3cebf1643007a464b86c5ee8afae4b7b
 Trifolium_pratense__JGI_v2-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/tpr.con.gz,files,88e4b2c180571ec8d24c84b0a72b6c95
-Thalassiosira_pseudonana_JGI_3_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/tps.fasta.gz,files,df4f77a45f88acb0dee211639fab2ae2
+Thalassiosira_pseudonana_JGI_3_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/tps.fasta.gz,files,95ef9fbfb29b91f9ac0d0cdce6d58314
 Triticum_turgidum_Svevo_v1_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_monocots_04_5/Genomes/ttu.fasta.gz,files,b4623a43cfc5210d7227bce8105a3598
 Utricularia_gibba__CoGe_v4-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/ugi.con.gz,files,76dccfdd84d034f48d847e8089293521
 Volvox_carteri_JGI_2_0_Phtyozome_10_2-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pico_03/Genomes/vca.fasta.gz,files,073ea3d5ae886e653f628a91338cd8b1


### PR DESCRIPTION
Here is the update of checksums for the fixed fasta sources (the one that was truncated and the empty one).
I've also removed some genomes from upstream servers (ENSEMBL) that are not directly plants related. These were just there to support the comparative genomics platform but should not populate the plantsref.  

- Fix #5 
- Fix #4