### PR TITLE
remove duplicated genome

### DIFF
--- a/asset_pep/recipe_inputs.csv
+++ b/asset_pep/recipe_inputs.csv
@@ -111,7 +111,6 @@ Ricinus_communis_JCVI_1_0-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_pub
 Ricinus_communis__JGI_v0_1-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/rco.con.gz,files,3508b3ce108fc78156796f0b8bb174f7
 Sorghum_bicolor_JGI_1_4-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_monocots_03/Genomes/sbi.con.gz,files,b164b172d671a6a393c09d5f7abdb84b
 Sorghum_bicolor_JGI_v3_1-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_monocots_04_5/Genomes/sbi.fasta.gz,files,813ebb087fac33199119266d2e4ad2ef
-Setaria_italica_JGI_8_3X_chromosome-scale_assembly_release_2_0_annotation_version_2_1-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_monocots_03/Genomes/sit.con.gz,files,9ede8e22816d388ad63d17f4f22397e2
 Setaria_italica_JGI_v2_2-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_monocots_04_5/Genomes/sit.fasta.gz,files,650591c5e36fa5ab60ae3e5d1d30555d
 Solanum_lycopersicum_ITAG_2_3-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_03/Genomes/sly.con.gz,files,a226442514ec53541a02b248851373e9
 Solanum_lycopersicum__Sol_Genomics_itag2_4-fasta,fasta,ftp://ftp.psb.ugent.be/pub/plaza/plaza_public_dicots_04/Genomes/sly.con.gz,files,23eab24233529855e17a6d15facf03bb


### PR DESCRIPTION
Fix #8 
Indeed these are exactly the same genomes. We used to keep both entries when there is a genome associated with more than 1 annotation, which was the case here. So, indeed it's a good catch you got by using sequence derived identifiers. this will surely be useful to also match genomes and annotation pairs.  